### PR TITLE
Fix links to internal documents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+build/
+__pycache__/
+*.egg-info/

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,19 @@
+# .readthedocs.yml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+version: 2
+
+formats: []
+
+python:
+   version: 3.7
+   install:
+      - requirements: tests/docs/requirements.txt
+      - method: setuptools
+        path: .
+
+sphinx:
+  builder: html
+  configuration: tests/docs/source/conf.py
+  fail_on_warning: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,44 @@
+language: python
+  - "3.7"
+
+install:
+  - pip install -r tests/docs/requirements.txt
+  - python3 setup.py install
+
+stages:
+  - name: Tests
+
+jobs:
+  - stage: Tests
+    name: "Build Tests"
+    script:
+      - cd tests/docs
+      - make html
+
+  - stage: Tests
+    name: "Sphinx < 3.0 Internal Link Test"
+    script:
+      - cd tests/docs
+      - pip3 install sphinx==2.4
+      - make TEST=int_link_test linkcheck
+
+  - stage: Tests
+    name: "Sphinx >= 3.0 Internal Link Test"
+    script:
+      - cd tests/docs
+      - pip3 install sphinx==3.0
+      - make TEST=int_link_test linkcheck
+
+  # - stage: Tests
+  #   name: "Sphinx < 3.0 External Link Test"
+  #   script:
+  #     - cd tests/docs
+  #     - pip3 install sphinx==2.4
+  #     - make TEST=ext_link_test linkcheck
+
+  # - stage: Tests
+  #   name: "Sphinx >= 3.0 External Link Test"
+  #   script:
+  #     - cd tests/docs
+  #     - pip3 install sphinx==3.0
+  #     - make TEST=ext_link_test linkcheck

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     url="https://github.com/SymbiFlow/markdown-code-symlinks",
     packages=setuptools.find_packages(),
-    install_requires=['docutils', 'sphinx', 'recommonmark'],
+    install_requires=['docutils', 'sphinx', 'recommonmark', 'packaging'],
     classifiers=[
         "Programming Language :: Python",
         "Programming Language :: Python :: 2",

--- a/tests/docs/Makefile
+++ b/tests/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = source
+BUILDDIR      = build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/tests/docs/make.bat
+++ b/tests/docs/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=source
+set BUILDDIR=build
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.http://sphinx-doc.org/
+	exit /b 1
+)
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/tests/docs/requirements.txt
+++ b/tests/docs/requirements.txt
@@ -1,0 +1,4 @@
+packaging
+
+sphinx==3.0
+recommonmark==0.6.0

--- a/tests/docs/source/conf.py
+++ b/tests/docs/source/conf.py
@@ -1,0 +1,106 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# This file only contains a selection of the most common options. For a full
+# list see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+import os
+import subprocess
+import sphinx
+import packaging.version
+from markdown_code_symlinks import LinkParser, MarkdownSymlinksDomain
+
+# -- Project information -----------------------------------------------------
+
+project = 'Markdown Symlinks Tests'
+copyright = '2020, SymbiFlow Authors'
+author = 'SymbiFlow Authors'
+
+# The full version, including alpha/beta/rc tags
+release = '1.0'
+
+# -- General configuration ---------------------------------------------------
+
+# Add any Sphinx extension module names here, as strings. They can be
+# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
+# ones.
+
+master_doc = 'index'
+
+sphinx_v3_0 = packaging.version.parse("3.0.0")
+sphinx_v = packaging.version.parse(sphinx.__version__)
+
+if sphinx_v >= sphinx_v3_0:
+    extensions = ['recommonmark']
+else:
+    extensions = []
+
+# Add any paths that contain templates here, relative to this directory.
+templates_path = ['_templates']
+
+# List of patterns, relative to source directory, that match files and
+# directories to ignore when looking for source files.
+# This pattern also affects html_static_path and html_extra_path.
+exclude_patterns = []
+
+# -- Options for HTML output -------------------------------------------------
+
+# The theme to use for HTML and HTML Help pages.  See the documentation for
+# a list of builtin themes.
+#
+html_theme = 'alabaster'
+
+# Add any paths that contain custom static files (such as style sheets) here,
+# relative to this directory. They are copied after the builtin static files,
+# so a file named "default.css" will overwrite the builtin "default.css".
+html_static_path = ['_static']
+
+# -- Tests --------------------------------------------------------------------
+
+if "TEST" in os.environ:
+    all_files = [f for f in os.listdir() if os.path.isfile(f)]
+    test_name = os.environ["TEST"]
+
+    if test_name == 'int_link_test':
+        master_doc = 'int_link_test'
+        used_files = ['int_link_test.md']
+    elif test_name == 'ext_link_test':
+        master_doc = 'ext_link_test'
+        used_files = [
+            'ext_link_test.md',
+            'int_file.md'
+        ]
+    else:
+        assert False, "Unsupported test name"
+
+    exclude_patterns = [x for x in all_files if x not in used_files]
+
+# -- Print Used Python Packages -----------------------------------------------
+
+subprocess.run("pip3 list --format=columns", shell=True)
+print("----------------------------------------------------------\n")
+
+# -- Markdown Symlinks Setup --------------------------------------------------
+
+source_parsers = {
+    '.md': 'markdown_code_symlinks.LinkParser',
+}
+
+source_suffix = ['.rst', '.md']
+
+
+def setup(app):
+    github_code_branch = 'blob/fix_links/'
+    github_code_repo = 'https://github.com/SymbiFlow/sphinxcontrib-markdown-symlinks/'
+
+    docs_root_dir = os.path.realpath(os.path.dirname(__file__))
+    code_root_dir = os.path.realpath(os.path.join(docs_root_dir, "..", ".."))
+
+    MarkdownSymlinksDomain.init_domain(
+        github_code_repo, github_code_branch, docs_root_dir, code_root_dir)
+    MarkdownSymlinksDomain.find_links()
+    app.add_domain(MarkdownSymlinksDomain)
+    app.add_config_value(
+        'recommonmark_config', {
+            'github_code_repo': github_code_repo,
+        }, True)

--- a/tests/docs/source/ext_link_test.md
+++ b/tests/docs/source/ext_link_test.md
@@ -1,0 +1,1 @@
+../../ext_link_test.md

--- a/tests/docs/source/index.rst
+++ b/tests/docs/source/index.rst
@@ -1,0 +1,17 @@
+:orphan:
+
+Markdown Symlinks Tests
+=======================
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Tests
+
+   ext_link_test.md
+   int_link_test.md
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Other files
+
+   int_file

--- a/tests/docs/source/int_file.md
+++ b/tests/docs/source/int_file.md
@@ -1,0 +1,1 @@
+../../test_files/int_file.md

--- a/tests/docs/source/int_link_test.md
+++ b/tests/docs/source/int_link_test.md
@@ -1,0 +1,1 @@
+../../int_link_test.md

--- a/tests/ext_link_test.md
+++ b/tests/ext_link_test.md
@@ -1,0 +1,11 @@
+# External Link Test
+
+This test contains a link to the markdown file that is not used in
+the Sphinx documentation. Therefore, after creating the symbolic link
+to this test in Sphinx documentation, the Markdown Symlinks should change
+the link inside this file to the Github URL.
+
+If this link works in the Sphinx documentation, the Markdown Symlinks
+extension correctly resolved the link reference:
+
+[Link to the file](test_files/file.md)

--- a/tests/int_link_test.md
+++ b/tests/int_link_test.md
@@ -1,0 +1,10 @@
+# Internal Link Test
+
+This test consists of a link to the markdown file, already used in
+the Sphinx documentation. In this case, the Markdown Symlinks extension
+should change the link used in this file to the file inside the documentation.
+
+If this link works in the Sphinx documentation, the Markdown Symlinks
+extension correctly resolved the link reference:
+
+[Link to the file](test_files/int_file.md)

--- a/tests/test_files/file.md
+++ b/tests/test_files/file.md
@@ -1,0 +1,3 @@
+# Test File
+
+This file is used for testing the Markdown Symlinks Extension

--- a/tests/test_files/int_file.md
+++ b/tests/test_files/int_file.md
@@ -1,0 +1,3 @@
+# Internal Test File
+
+This file is used for testing the Markdown Symlinks Extension


### PR DESCRIPTION
The links to markdown files used by the Sphinx documentation are not working correctly when using the Markdown Symlinks locally. 

This PR introduces the changes that allow generating correct documentation locally. The changes need to be tested on RTD. 
The PR also provides basic tests for the Sphinx extension.